### PR TITLE
Make it possible to access custom event details from user scripts

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,7 @@ env:
 globals:
   process: false
   content: false
+  cloneInto: false
 
 overrides:
   - files:

--- a/src/lib/content/fetchHTMLText.js
+++ b/src/lib/content/fetchHTMLText.js
@@ -30,16 +30,23 @@ async function nativeFetch(url) {
   return {responseURL, responseText};
 }
 
+function dispatchCustomEvent(type, options) {
+  document.dispatchEvent(
+    new document.defaultView.CustomEvent(
+      type,
+      cloneInto(options, document.defaultView)
+    )
+  );
+}
+
 async function userFetch(url) {
   const eventPromise = waitForEvent(document, "AutoPagerizeUserFetchResponse");
-  document.dispatchEvent(
-    new CustomEvent("AutoPagerizeUserFetchRequest", {
-      bubbles: true,
-      detail: {
-        url: url.href,
-      },
-    })
-  );
+  dispatchCustomEvent("AutoPagerizeUserFetchRequest", {
+    bubbles: true,
+    detail: {
+      url: url.href,
+    },
+  });
 
   const ev = await eventPromise;
   const {responseURL, responseText} = ev.detail;
@@ -51,15 +58,13 @@ async function responseFilter(response) {
     document,
     "AutoPagerizeResponseFilterResponse"
   );
-  document.dispatchEvent(
-    new CustomEvent("AutoPagerizeResponseFilterRequest", {
-      bubbles: true,
-      detail: {
-        responseURL: response.responseURL.href,
-        responseText: response.responseText,
-      },
-    })
-  );
+  dispatchCustomEvent("AutoPagerizeResponseFilterRequest", {
+    bubbles: true,
+    detail: {
+      responseURL: response.responseURL.href,
+      responseText: response.responseText,
+    },
+  });
 
   const ev = await eventPromise;
   const {responseText} = ev.detail;


### PR DESCRIPTION
`AutoPagerizeUserFetchRequest`, `AutoPagerizeResponseFilterRequest`. 
Firefox isolates between content scripts and page scripts.
So, an error occurred when an user or page script tried to access `event.detail.x`.
`Error: Permission denied to access property "x"`.
Use `cloneInto` to fix this.

// ところでこの addon は palemoon や waterfox とかのFirefoxフォークはターゲットに入ってます？
// 2019年に pixiv.js の更新がありましたが、当時時点で Firefox では上記eventのdetailにはアクセス出来なかった思うんですが。